### PR TITLE
Passing encryptedEvents to Append

### DIFF
--- a/src/Log4NetMessageEncryptor/MessageEncryptingForwardingAppender.cs
+++ b/src/Log4NetMessageEncryptor/MessageEncryptingForwardingAppender.cs
@@ -104,7 +104,7 @@ namespace ArtisanCode.Log4NetMessageEncryptor
         {
             var encryptedEvents = loggingEvents.Select(x => GenerateEncryptedLogEvent(x)).ToArray();
 
-            base.Append(loggingEvents);
+            base.Append(encryptedEvents);
         }
 
         /// <summary>


### PR DESCRIPTION
I don't really know, when this method ActionAppend(LoggingEvent[] loggingEvents) is called, but I suppose this is how it should be implemented.
